### PR TITLE
Use active_record

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,0 +1,3 @@
+class ApplicationRecord < ActiveRecord::Base
+  self.abstract_class = true
+end

--- a/app/models/artist.rb
+++ b/app/models/artist.rb
@@ -1,3 +1,3 @@
-class Artist < ActiveRecord::Base
+class Artist < ApplicationRecord
   has_many :songs
 end

--- a/app/models/song.rb
+++ b/app/models/song.rb
@@ -1,8 +1,8 @@
-class Song < ActiveRecord::Base
+class Song < ApplicationRecord
   belongs_to :artist, optional: true
 
   def artist_name
-    self.try(:artist).try(:name)
+    try(:artist).try(:name)
   end
 
   def artist_name=(name)


### PR DESCRIPTION
This pull request refactors the model inheritance structure to introduce a shared `ApplicationRecord` base class, aligning with Rails best practices. All models now inherit from `ApplicationRecord` instead of directly from `ActiveRecord::Base`.

Model inheritance refactor:

* Added new `ApplicationRecord` class as an abstract base class for all models (`app/models/application_record.rb`).
* Updated `Artist` and `Song` models to inherit from `ApplicationRecord` instead of `ActiveRecord::Base` (`app/models/artist.rb`, `app/models/song.rb`). [[1]](diffhunk://#diff-e50bb3903ab59fb96fad5e8d8d1ff481fcde3cb05a522f751e61bc07d1a7c828L1-R1) [[2]](diffhunk://#diff-e4bac0a998cf8010fedddef163fde3ece65ae7ba546f65208555b4310e45e7b4L1-R5)

Minor code cleanup:

* Simplified the `artist_name` method in the `Song` model by removing unnecessary use of `self` (`app/models/song.rb`).